### PR TITLE
improve virtual env activation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,21 @@ cd OpenManus
 3. Create a new virtual environment and activate it:
 
 ```bash
-uv venv
-source .venv/bin/activate  # On Unix/macOS
-# Or on Windows:
-# .venv\Scripts\activate
+# Create virtual environment (all systems)
+uv venv --python 3.12
+
+# Activation commands
+# Linux/macOS (bash/zsh):
+source .venv/bin/activate
+
+# Linux/macOS (fish shell):
+source .venv/bin/activate.fish
+
+# Windows (cmd.exe):
+.venv\Scripts\activate.bat
+
+# Windows (PowerShell):
+.venv\Scripts\Activate.ps1
 ```
 
 4. Install dependencies:


### PR DESCRIPTION
**Features**

  -  Set explicit Python 3.12 requirement for virtual environment creation to prevent compatibility issues when system default is <3.11
  -  Add platform-specific activation commands for fish shell and PowerShell

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

```bash
# Create virtual environment (all systems)
uv venv --python 3.12

# Activation commands
# Linux/macOS (bash/zsh):
source .venv/bin/activate

# Linux/macOS (fish shell):
source .venv/bin/activate.fish

# Windows (cmd.exe):
.venv\Scripts\activate.bat

# Windows (PowerShell):
.venv\Scripts\Activate.ps1
```

```bash
# 创建虚拟环境（所有系统通用）
uv venv --python 3.12

# 激活虚拟环境（根据系统选择）
# Linux/macOS (bash/zsh):
source .venv/bin/activate

# Linux/macOS (fish shell):
source .venv/bin/activate.fish

# Windows (cmd.exe):
.venv\Scripts\activate.bat

# Windows (PowerShell):
.venv\Scripts\Activate.ps1
```

**Other**
<!-- Additional notes about this PR. -->
