### PR TITLE
chore: update .gitignore to ignore config.toml 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,5 @@ data/
 
 # Workspace
 workspace/
+
+config/config.toml


### PR DESCRIPTION
Add config/config.toml to .gitignore to prevent sensitive configuration files from being accidentally committed to the version control system.

**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Feature 1
- Feature 2

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

**Other**
<!-- Additional notes about this PR. -->
