### PR TITLE
Update config.example.toml

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1,7 +1,7 @@
 # Global LLM configuration
 [llm]
 model = "claude-3-7-sonnet-20250219"        # The LLM model to use
-base_url = "https://api.anthropic.com/v1/"  # API endpoint URL
+base_url = "https://api.anthropic.com"  # API endpoint URL
 api_key = "YOUR_API_KEY"                    # Your API key
 max_tokens = 8192                           # Maximum number of tokens in the response
 temperature = 0.0                           # Controls randomness
@@ -26,7 +26,7 @@ temperature = 0.0                           # Controls randomness
 # Optional configuration for specific LLM models
 [llm.vision]
 model = "claude-3-7-sonnet-20250219"        # The vision model to use
-base_url = "https://api.anthropic.com/v1/"  # API endpoint URL for vision model
+base_url = "https://api.anthropic.com"  # API endpoint URL for vision model
 api_key = "YOUR_API_KEY"                    # Your API key for vision model
 max_tokens = 8192                           # Maximum number of tokens in the response
 temperature = 0.0                           # Controls randomness for vision model


### PR DESCRIPTION
Fix example config for anthropic llms

**Features**
Anthropic base url is incorrect in the example config

**Feature Docs**
most people are copying the example config and are finding anthropic llm config doesnt work and switching to  openai

**Influence**
It appears that the LiteLLM integration is failing to communicate with Anthropic’s API. The error log shows that a request is being sent to:


```bash
https://api.anthropic.com/v1/v1/messages
```

**Result**

**Other**
<!-- Additional notes about this PR. -->
