### PR TITLE
feat(agent): add chat sanitizer and strict chat structure support

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -19,7 +19,9 @@ class Manus(ToolCallAgent):
     """A versatile general-purpose agent with support for both local and MCP tools."""
 
     name: str = "Manus"
-    description: str = "A versatile agent that can solve various tasks using multiple tools including MCP-based tools"
+    description: str = (
+        "A versatile agent that can solve various tasks using multiple tools including MCP-based tools"
+    )
 
     system_prompt: str = SYSTEM_PROMPT.format(directory=config.workspace_root)
     next_step_prompt: str = NEXT_STEP_PROMPT
@@ -59,7 +61,12 @@ class Manus(ToolCallAgent):
     @classmethod
     async def create(cls, **kwargs) -> "Manus":
         """Factory method to create and properly initialize a Manus instance."""
-        instance = cls(**kwargs)
+        from app.config import config
+
+        strict = config.llm["default"].strict_chat_structure
+
+        instance = cls(strict_chat_structure=strict, **kwargs)
+
         await instance.initialize_mcp_servers()
         instance._initialized = True
         return instance

--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,9 @@ class LLMSettings(BaseModel):
     temperature: float = Field(1.0, description="Sampling temperature")
     api_type: str = Field(..., description="Azure, Openai, or Ollama")
     api_version: str = Field(..., description="Azure Openai version if AzureOpenai")
+    strict_chat_structure: bool = Field(
+        False, description="Strict chat structure (agent/user order)"
+    )
 
 
 class ProxySettings(BaseModel):
@@ -215,6 +218,7 @@ class Config:
             "temperature": base_llm.get("temperature", 1.0),
             "api_type": base_llm.get("api_type", ""),
             "api_version": base_llm.get("api_version", ""),
+            "strict_chat_structure": base_llm.get("strict_chat_structure", False),
         }
 
         # handle browser config.


### PR DESCRIPTION
# **Features**

- **Add `sanitize_message_history`**: Introduced a helper method to sanitize the chat history by inserting an acknowledgement message when a `tool` message is immediately followed by a `user` message. This ensures compatibility with APIs like Mistral that require strict message alternation between roles.
- **Add `strict_chat_structure` flag**: Added an optional `strict_chat_structure` boolean field to agents. It is set during creation based on configuration and can be used to enforce stricter validation or formatting rules when interacting with certain LLMs. If the flag is not set at all then it goes ahead just as it would before it was implemented.

# **Feature Docs**

- N/A (small utility and configuration update for internal consistency and API compatibility).
- Use case: When integrating with APIs like Mistral, which expect strict alternation between assistant/user messages.

# **Influence**

- **Backwards compatible**: These changes are non-breaking and opt-in (default behavior is unchanged unless `strict_chat_structure` is enabled).
- **Extensibility**: Prepares the system to better support LLMs that have stricter chat format requirements.
- **Internal agent behavior**: Slight modification of message history prior to sending a request, but only when necessary.

# **Result**

- The system correctly sanitizes message history during agent `think` steps without user intervention.
- Agents can now be optionally configured to operate in strict chat structure mode.

# **Other**

- Future improvements might include dynamically toggling strictness per model or endpoint.
- Related cleanup or enhancements could make this sanitizer more generic across the app.
