### PR TITLE
fix an error where role 'tool' is not a response to a preceding messa…

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -166,6 +166,8 @@ class Memory(BaseModel):
         # Optional: Implement message limit
         if len(self.messages) > self.max_messages:
             self.messages = self.messages[-self.max_messages :]
+            while self.messages[0].role == "tool":
+                self.messages = self.messages[1:]
 
     def add_messages(self, messages: List[Message]) -> None:
         """Add multiple messages to memory"""
@@ -173,6 +175,8 @@ class Memory(BaseModel):
         # Optional: Implement message limit
         if len(self.messages) > self.max_messages:
             self.messages = self.messages[-self.max_messages :]
+            while self.messages[0].role == "tool":
+                self.messages = self.messages[1:]
 
     def clear(self) -> None:
         """Clear all messages"""


### PR DESCRIPTION
# Fix for OpenAI API Tool Message Error

## Changes
Added modifications to handle tool messages in the `add_message` and `add_messages` methods of the `Memory` class in `schema.py`.

Specifically, when the number of messages exceeds `max_messages`, we now remove any leading messages with `role="tool"`.

## Background
When using the OpenAI API, the following error was occurring:
ERROR | app.llm:ask_tool:768 - API error: Error code: 400 - {'error': {'message': "Messages with role 'tool' must be a response to a preceding message with 'tool_calls'", 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}

This error occurs when a message with `role="tool"` is not preceded by a message containing `tool_calls`.

## Solution
When the message history exceeds `max_messages`, we now remove any leading messages with `role="tool"`. This prevents tool messages from being sent without the proper context.

## Impact
This fix only affects message history management when using the OpenAI API. It has no impact on other functionality.

## Testing
- [x] Verified behavior when message count exceeds `max_messages`
- [x] Confirmed proper handling of tool messages
- [x] Verified successful processing of OpenAI API requests
