### PR TITLE
feat: Make bedrock client to use adaptive retries

### DIFF
--- a/app/bedrock.py
+++ b/app/bedrock.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Dict, List, Literal, Optional
 
 import boto3
+from botocore.config import Config
 
 
 # Global variables to track the current tool use ID across function calls
@@ -39,7 +40,18 @@ class BedrockClient:
     def __init__(self):
         # Initialize Bedrock client, you need to configure AWS env first
         try:
-            self.client = boto3.client("bedrock-runtime")
+            # set up AWS boto3 retries
+            # <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html>
+            config = Config(
+                retries = {
+                    'max_attempts': 5,
+                    'mode': 'adaptive'
+                }
+            )
+            self.client = boto3.client(
+                "bedrock-runtime",
+                config=config,
+            )
             self.chat = Chat(self.client)
         except Exception as e:
             print(f"Error initializing Bedrock client: {e}")


### PR DESCRIPTION
**Features**

- Make bedrock runtime client to use adaptive retries rather than using legacy retry logics
    - [boto3 retries](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html)

**Feature Docs**
Boto3 client uses 'legacy retry' option as default, which has limited retry features.
It is better to use either 'standard' or 'adaptive' retry option.

Adaptive retry mode is an experimental retry mode that includes all the features of standard mode. In addition to the standard mode features, adaptive mode also introduces client-side rate limiting through the use of a token bucket and rate-limit variables that are dynamically updated with each retry attempt. This mode offers flexibility in client-side retries that adapts to the error/exception state response from an AWS service.
