### PR TITLE
Add environment variable (env) support for MCP’s stdio transport.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,9 @@ class MCPServerConfig(BaseModel):
     args: List[str] = Field(
         default_factory=list, description="Arguments for stdio command"
     )
+    env: Dict[str, str] = Field(
+        default_factory=dict, description="Environment variables for stdio server needed"
+    )
 
 
 class MCPSettings(BaseModel):
@@ -140,6 +143,7 @@ class MCPSettings(BaseModel):
                         url=server_config.get("url"),
                         command=server_config.get("command"),
                         args=server_config.get("args", []),
+                        env=server_config.get("env", {}),
                     )
                 return servers
         except Exception as e:

--- a/app/tool/mcp.py
+++ b/app/tool/mcp.py
@@ -69,7 +69,7 @@ class MCPClients(ToolCollection):
         await self._initialize_and_list_tools(server_id)
 
     async def connect_stdio(
-        self, command: str, args: List[str], server_id: str = ""
+        self, command: str, args: List[str], server_id: str = "", env: Dict[str, str] = {}
     ) -> None:
         """Connect to an MCP server using stdio transport."""
         if not command:
@@ -84,7 +84,7 @@ class MCPClients(ToolCollection):
         exit_stack = AsyncExitStack()
         self.exit_stacks[server_id] = exit_stack
 
-        server_params = StdioServerParameters(command=command, args=args)
+        server_params = StdioServerParameters(command=command, args=args, env=env)
         stdio_transport = await exit_stack.enter_async_context(
             stdio_client(server_params)
         )

--- a/config/mcp.example.json
+++ b/config/mcp.example.json
@@ -1,8 +1,19 @@
 {
-    "mcpServers": {
-      "server1": {
-        "type": "sse",
-        "url": "http://localhost:8000/sse"
+  "mcpServers": {
+    "server1": {
+      "type": "sse",
+      "url": "http://localhost:8000/sse"
+    },
+    "sequential-thinking": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ],
+      "env": {
+        "test": "test"
       }
     }
+  }
 }


### PR DESCRIPTION
Add environment variable (env) support for MCP’s stdio transport to address dependencies of stdio-based MCP servers on environment variables.

**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Feature 1: For stdio-based MCP servers like the [GitHub MCP Server](https://github.com/github/github-mcp-server), the tools execution relies on the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable for authentication. Environment variable support has been added for stdio MCP servers.

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->
In the `mcp.json` configuration file, environment variable dependencies for a server can be added under `mcpServers.server.env`, which is a dictionary variable.

```json
{
  "mcpServers": {
    "github": {
      "type": "stdio",
      "command": "${ROOT_PATH}/github-mcp-server/github-mcp-server",
      "args": [
        "stdio"
      ],
      "env": {
        "GITHUB_PERSONAL_ACCESS_TOKEN": "${github_access_token}"
      }
    }
  }
}

```

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

```bash
INFO     [browser_use] BrowserUse logging setup complete with level info
INFO     [root] Anonymized telemetry enabled. See https://docs.browser-use.com/development/telemetry for more information.
GitHub MCP Server running on stdio
2025-05-21 11:29:28.547 | INFO     | app.tool.mcp:_initialize_and_list_tools:124 - Connected to server github with tools: ['add_issue_comment', 'create_branch', 'create_issue', 'create_or_update_file', 'create_pull_request', 'create_pull_request_review', 'create_repository', 'fork_repository', 'get_code_scanning_alert', 'get_file_contents', 'get_issue', 'get_issue_comments', 'get_me', 'get_pull_request', 'get_pull_request_comments', 'get_pull_request_files', 'get_pull_request_reviews', 'get_pull_request_status', 'list_code_scanning_alerts', 'list_commits', 'list_issues', 'list_pull_requests', 'merge_pull_request', 'push_files', 'search_code', 'search_issues', 'search_repositories', 'search_users', 'update_issue', 'update_pull_request_branch']
2025-05-21 11:29:28.547 | INFO     | app.agent.manus:initialize_mcp_servers:95 - Connected to MCP server github using command /Users/wangwei17/Documents/Project/github/github-mcp-server/github-mcp-server with arguments ['stdio']
```

**Other**
<!-- Additional notes about this PR. -->
