### PR TITLE
fix: sanitize MCP tool names for OpenAI API compliance

### DIFF
--- a/app/tool/mcp.py
+++ b/app/tool/mcp.py
@@ -1,6 +1,7 @@
 from contextlib import AsyncExitStack
 from typing import Dict, List, Optional
 
+from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.types import ListToolsResult, TextContent
@@ -8,7 +9,6 @@ from mcp.types import ListToolsResult, TextContent
 from app.logger import logger
 from app.tool.base import BaseTool, ToolResult
 from app.tool.tool_collection import ToolCollection
-from mcp import ClientSession, StdioServerParameters
 
 
 class MCPClientTool(BaseTool):
@@ -106,8 +106,8 @@ class MCPClients(ToolCollection):
         # Create proper tool objects for each server tool
         for tool in response.tools:
             original_name = tool.name
-            # Always prefix with server_id to ensure uniqueness
             tool_name = f"mcp_{server_id}_{original_name}"
+            tool_name = self._sanitize_tool_name(tool_name)
 
             server_tool = MCPClientTool(
                 name=tool_name,
@@ -124,6 +124,25 @@ class MCPClients(ToolCollection):
         logger.info(
             f"Connected to server {server_id} with tools: {[tool.name for tool in response.tools]}"
         )
+
+    def _sanitize_tool_name(self, name: str) -> str:
+        """Sanitize tool name to match MCPClientTool requirements."""
+        import re
+
+        # Replace invalid characters with underscores
+        sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+
+        # Remove consecutive underscores
+        sanitized = re.sub(r"_+", "_", sanitized)
+
+        # Remove leading/trailing underscores
+        sanitized = sanitized.strip("_")
+
+        # Truncate to 64 characters if needed
+        if len(sanitized) > 64:
+            sanitized = sanitized[:64]
+
+        return sanitized
 
     async def list_tools(self) -> ListToolsResult:
         """List all available tools."""


### PR DESCRIPTION
Tool names with invalid characters (slashes, dots) from server paths were causing OpenAI API 400 errors. Added sanitization to ensure names match required pattern ^[a-zA-Z0-9_-]{1,64}$.

Fixes #1143

**Result**
it no longer fails at the tool calling step
<img width="1003" alt="Screenshot 2025-05-29 at 11 00 12 PM" src="https://github.com/user-attachments/assets/a8b0b3af-2864-426c-a288-6f77735ff1cf" />

