### PR TITLE
Add prompt input parser into main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,14 +1,23 @@
 import asyncio
+import argparse
 
 from app.agent.manus import Manus
 from app.logger import logger
 
 
 async def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Run Manus agent with a prompt")
+    parser.add_argument(
+        "--prompt", type=str, required=False, help="Input prompt for the agent"
+    )
+    args = parser.parse_args()
+
     # Create and initialize Manus agent
     agent = await Manus.create()
     try:
-        prompt = input("Enter your prompt: ")
+        # Use command line prompt if provided, otherwise ask for input
+        prompt = args.prompt if args.prompt else input("Enter your prompt: ")
         if not prompt.strip():
             logger.warning("Empty prompt provided.")
             return


### PR DESCRIPTION
Add prompt input parser into main.py

So user can be calling like 
`python3 main.py --prompt "thins is an example prompt"`

the prompt parser is designed to be optional