### PR TITLE
add env support for stdio mcp server configuration

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -81,6 +81,7 @@ class Manus(ToolCallAgent):
                             server_id,
                             use_stdio=True,
                             stdio_args=server_config.args,
+                            env=server_config.env,
                         )
                         logger.info(
                             f"Connected to MCP server {server_id} using command {server_config.command}"
@@ -94,11 +95,12 @@ class Manus(ToolCallAgent):
         server_id: str = "",
         use_stdio: bool = False,
         stdio_args: List[str] = None,
+        env: Dict[str, str] = None,
     ) -> None:
         """Connect to an MCP server and add its tools."""
         if use_stdio:
             await self.mcp_clients.connect_stdio(
-                server_url, stdio_args or [], server_id
+                server_url, stdio_args or [], env, server_id
             )
             self.connected_servers[server_id or server_url] = server_url
         else:

--- a/app/agent/mcp.py
+++ b/app/agent/mcp.py
@@ -43,6 +43,7 @@ class MCPAgent(ToolCallAgent):
         server_url: Optional[str] = None,
         command: Optional[str] = None,
         args: Optional[List[str]] = None,
+        env: Optional[dict[str, str]] = None,
     ) -> None:
         """Initialize the MCP connection.
 
@@ -63,7 +64,7 @@ class MCPAgent(ToolCallAgent):
         elif self.connection_type == "stdio":
             if not command:
                 raise ValueError("Command is required for stdio connection")
-            await self.mcp_clients.connect_stdio(command=command, args=args or [])
+            await self.mcp_clients.connect_stdio(command=command, args=args or [], env=env)
         else:
             raise ValueError(f"Unsupported connection type: {self.connection_type}")
 

--- a/app/config.py
+++ b/app/config.py
@@ -114,6 +114,9 @@ class MCPServerConfig(BaseModel):
     args: List[str] = Field(
         default_factory=list, description="Arguments for stdio command"
     )
+    env: Dict[str, str] = Field(
+        default_factory=dict, description="Environment variables for stdio command"
+    )
 
 
 class MCPSettings(BaseModel):
@@ -146,6 +149,7 @@ class MCPSettings(BaseModel):
                         url=server_config.get("url"),
                         command=server_config.get("command"),
                         args=server_config.get("args", []),
+                        env=server_config.get("env"),
                     )
                 return servers
         except Exception as e:

--- a/app/tool/mcp.py
+++ b/app/tool/mcp.py
@@ -69,7 +69,7 @@ class MCPClients(ToolCollection):
         await self._initialize_and_list_tools(server_id)
 
     async def connect_stdio(
-        self, command: str, args: List[str], server_id: str = ""
+        self, command: str, args: List[str], env: Dict[str, str], server_id: str = ""
     ) -> None:
         """Connect to an MCP server using stdio transport."""
         if not command:
@@ -84,7 +84,7 @@ class MCPClients(ToolCollection):
         exit_stack = AsyncExitStack()
         self.exit_stacks[server_id] = exit_stack
 
-        server_params = StdioServerParameters(command=command, args=args)
+        server_params = StdioServerParameters(command=command, args=args, env=env)
         stdio_transport = await exit_stack.enter_async_context(
             stdio_client(server_params)
         )

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,2 +1,3 @@
 # prevent the local config file from being uploaded to the remote repository
 config.toml
+mcp.json


### PR DESCRIPTION
**Features**
- Add env support for stdio mcp server configuration

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

Most of MCP Client support this feature, like [Cursor](https://docs.cursor.com/context/model-context-protocol#manual-configuration).

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->
Self test passed. If u have any CI test flow, please let me know.

![image](https://github.com/user-attachments/assets/35a5c2dc-01c6-4160-b278-98c33d2e2325)

![image](https://github.com/user-attachments/assets/31c2f584-c029-4f37-a8f3-232fadad1180)


**Other**
<!-- Additional notes about this PR. -->
