### PR TITLE
fix(prompt): Refine terminate condition to prevent infinite loop (Fixes #1133)

### DIFF
--- a/app/prompt/manus.py
+++ b/app/prompt/manus.py
@@ -6,5 +6,5 @@ SYSTEM_PROMPT = (
 NEXT_STEP_PROMPT = """
 Based on user needs, proactively select the most appropriate tool or combination of tools. For complex tasks, you can break down the problem and use different tools step by step to solve it. After using each tool, clearly explain the execution results and suggest the next steps.
 
-If you want to stop the interaction at any point, use the `terminate` tool/function call.
+If you believe the task is complete, or if the user's question can be answered directly without using a tool, provide your final answer and then call the `terminate` tool to end the conversation.
 """


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->https://github.com/FoundationAgents/OpenManus/issues/1133

- Fixed an infinite loop bug that occurs when the agent is given an open-ended task (like 'introduce yourself'). The agent would misinterpret the LLM's follow-up question as an incomplete task, causing it to repeat.
- This resolves issue #1133.

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
- Improves the stability and reliability of the agent, ensuring it doesn't get stuck on simple, open-ended commands.

**Result**
The prompt change directly resolves the loop. By forcing the model to provide a final answer and then call `terminate`, the agent now correctly ends the conversation.
![image](https://github.com/user-attachments/assets/54f54f6b-72a9-4ed3-b333-24c98d66d5ae)

**Prompt Change Details:**
```diff
- If you want to stop the interaction at any point, use the `terminate` tool/function call.
+ If you believe the task is complete, or if the user's question can be answered directly without using a tool, provide your final answer and then call the `terminate` tool to end the conversation.

**Other**
<!-- Additional notes about this PR. -->
