### PR TITLE
Add super().__init__(message) to preserve exception message handling

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -2,6 +2,7 @@ class ToolError(Exception):
     """Raised when a tool encounters an error."""
 
     def __init__(self, message):
+        super().__init__(message)
         self.message = message
 
 


### PR DESCRIPTION
For easier error handling, pass messages to exception.
