### PR TITLE
Adding gpt-5 support by updating REASONING_MODELS, MULTIMODAL_MODELS

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -30,12 +30,13 @@ from app.schema import (
     ToolChoice,
 )
 
-
-REASONING_MODELS = ["o1", "o3-mini"]
+REASONING_MODELS = ["o1", "o3-mini", "gpt-5", "gpt-5-mini"]
 MULTIMODAL_MODELS = [
     "gpt-4-vision-preview",
     "gpt-4o",
     "gpt-4o-mini",
+    "gpt-5",
+    "gpt-5-mini",
     "claude-3-opus-20240229",
     "claude-3-sonnet-20240229",
     "claude-3-haiku-20240307",


### PR DESCRIPTION
**Features**
- GPT-5 was recently [launched](https://openai.com/index/introducing-gpt-5/) but is not included in the list of reasoning models or multi-modal models.
- This change adds support for the new models.  

**Influence**
- Before this change, when attempting to use GPT-5, the following error would be thrown

```
2025-08-09 16:09:49.810 | ERROR    | app.llm:ask_tool:756 - OpenAI API error: Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': 'unsupported_parameter'}}
```
- With this change, the above issue is addressed and the tool supports call to GPT-5 models.
- Adding both `gpt-5` and `gpt-5-mini` models 