### PR TITLE
fix(planning): Fix JSON parsing issues in tool parameters

### DIFF
--- a/app/flow/planning.py
+++ b/app/flow/planning.py
@@ -183,6 +183,11 @@ class PlanningFlow(BaseFlow):
                     args = tool_call.function.arguments
                     if isinstance(args, str):
                         try:
+                           # Intercepting a valid JSON string
+                            start = args.find("{")
+                            end = args.rfind("}") + 1
+                            if start != -1 and end != -1:
+                                args = args[start:end]
                             args = json.loads(args)
                         except json.JSONDecodeError:
                             logger.error(f"Failed to parse tool arguments: {args}")


### PR DESCRIPTION
Improve JSON string extraction from tool parameters to handle cases with extra characters

Fixes parsing failures like:
{"command": "create", "title": "Plan for Beijing Trip", "steps": [...]} <//tool_cal
<img width="1144" height="159" alt="image" src="https://github.com/user-attachments/assets/6102278c-6b96-4951-97a7-8fd42f5c0f0e" />

**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Completes a simple extract of the JSON format

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

<img width="1140" height="187" alt="image" src="https://github.com/user-attachments/assets/ace164cf-0879-4750-9eba-7f9510ec067a" />


