### PR TITLE
chore: update html2text to 2025.4.15 and crawl4ai to 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ datasets~=3.4.1
 fastapi~=0.115.11
 tiktoken~=0.9.0
 
-html2text~=2024.2.26
+html2text~=2025.4.15
 gymnasium~=1.1.1
 pillow~=11.1.0
 browsergym~=0.13.3
@@ -36,7 +36,7 @@ boto3~=1.37.18
 
 requests~=2.32.3
 beautifulsoup4~=4.13.3
-crawl4ai~=0.6.3
+crawl4ai~=0.7.0
 
 huggingface-hub~=0.29.2
 setuptools~=75.8.0


### PR DESCRIPTION
**Features**

- Update `html2text` to `2025.4.15` and `crawl4ai` to `0.7.0`
- Fix Python 3.12 compatibility and dependency conflicts

Fixes #1224

**Influence**

- Resolves installation failures with `uv` and `pip`
- Fixes `pillow` version conflicts between dependencies

**Result**

- Dependencies install successfully without conflicts
- Compatible with Python 3.12
