### PR TITLE
add Daytona toggle switch

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -106,7 +106,8 @@ class SandboxSettings(BaseModel):
 
 
 class DaytonaSettings(BaseModel):
-    daytona_api_key: str
+    use_daytona: bool = Field(False, description="Whether to use the daytona")
+    daytona_api_key: Optional[str] = Field(None, description="Daytona API key")
     daytona_server_url: Optional[str] = Field(
         "https://app.daytona.io/api", description=""
     )

--- a/app/daytona/tool_base.py
+++ b/app/daytona/tool_base.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, ClassVar, Dict, Optional
 
-from daytona import Daytona, DaytonaConfig, Sandbox, SandboxState
+from daytona import Sandbox, SandboxState
 from pydantic import Field
 
 from app.config import config
-from app.daytona.sandbox import create_sandbox, start_supervisord_session
+from app.daytona.sandbox import create_sandbox, daytona, start_supervisord_session
 from app.tool.base import BaseTool
 from app.utils.files_utils import clean_path
 from app.utils.logger import logger
@@ -14,12 +14,6 @@ from app.utils.logger import logger
 
 # load_dotenv()
 daytona_settings = config.daytona
-daytona_config = DaytonaConfig(
-    api_key=daytona_settings.daytona_api_key,
-    server_url=daytona_settings.daytona_server_url,
-    target=daytona_settings.daytona_target,
-)
-daytona = Daytona(daytona_config)
 
 
 @dataclass
@@ -70,6 +64,9 @@ class SandboxToolsBase(BaseTool):
 
     async def _ensure_sandbox(self) -> Sandbox:
         """Ensure we have a valid sandbox instance, retrieving it from the project if needed."""
+        if not daytona:
+            raise RuntimeError("Daytona is not enabled. Sandbox tools are unavailable.")
+
         if self._sandbox is None:
             # Get or start the sandbox
             try:
@@ -135,4 +132,5 @@ class SandboxToolsBase(BaseTool):
         """Clean and normalize a path to be relative to /workspace."""
         cleaned_path = clean_path(path, self.workspace_path)
         logger.debug(f"Cleaned path: {path} -> {cleaned_path}")
+        return cleaned_path
         return cleaned_path

--- a/config/config.example-daytona.toml
+++ b/config/config.example-daytona.toml
@@ -97,6 +97,7 @@ temperature = 0.0                          # Controls randomness for vision mode
 
 # Daytona configuration
 [daytona]
+use_daytona = true
 daytona_api_key = ""
 #daytona_server_url = "https://app.daytona.io/api"
 #daytona_target = "us"                                   #Daytona is currently available in the following regions:United States (us)、Europe (eu)


### PR DESCRIPTION
Since there are special scenarios where users cannot connect to Daytona, and having Daytona enabled by default may cause issues, it is hoped that a Daytona switch can be added to accommodate usage in such specific situations.

Resolves #1233

**Features**
- Add Daytona service toggle configuration
- Set config.example-daytona.toml default value to true to maintain current behavior

**Feature Docs**

**Influence**

**Result**

**Other**
