### PR TITLE
Update sanitization logic in mcp.py

### DIFF
--- a/app/tool/mcp.py
+++ b/app/tool/mcp.py
@@ -140,7 +140,7 @@ class MCPClients(ToolCollection):
 
         # Truncate to 64 characters if needed
         if len(sanitized) > 64:
-            sanitized = sanitized[:64]
+            sanitized = 'mcp_' + sanitized[-60:]
 
         return sanitized
 


### PR DESCRIPTION
Change sanitization logic to prepend 'mcp_' and keep last 60 characters.

When we connect mcp server by sse,server_id is always equals server_url, our tool_name like this
```
tool_name = f"mcp_{server_id}_{original_name}"
```
Because server_id contains both url and key, its length is always greater than 64, so all tool_name are the same
```
self.tool_map[tool_name] = server_tool
```
Resulting in only the last tool being saved, while the others are overwritten

