### PR TITLE
fix: correct special tool detection for MCP-prefixed tools

### DIFF
--- a/app/agent/mcp.py
+++ b/app/agent/mcp.py
@@ -164,10 +164,26 @@ class MCPAgent(ToolCallAgent):
                 )
             )
 
+    def _is_special_tool(self, name: str) -> bool:
+        """Check if tool name is in special tools list, including MCP prefixed tools"""
+        name_lower = name.lower()
+        # Check exact match first
+        if name_lower in [n.lower() for n in self.special_tool_names]:
+            return True
+        # Check if it's an MCP tool ending with a special tool name
+        # MCP tools have format: mcp_{server_id}_{original_name}
+        for special_name in self.special_tool_names:
+            if name_lower.endswith(f"_{special_name.lower()}") or name_lower.endswith(
+                special_name.lower()
+            ):
+                return True
+        return False
+
     def _should_finish_execution(self, name: str, **kwargs) -> bool:
         """Determine if tool execution should finish the agent"""
-        # Terminate if the tool name is 'terminate'
-        return name.lower() == "terminate"
+        # Terminate if the tool name is 'terminate' or ends with '_terminate' (for MCP tools)
+        name_lower = name.lower()
+        return name_lower == "terminate" or name_lower.endswith("_terminate")
 
     async def cleanup(self) -> None:
         """Clean up MCP connection when done."""


### PR DESCRIPTION
**Features**

* Fix `_is_special_tool` so that MCP-wrapped tools (named like `mcp_{server_id}_{tool_name}`) are correctly recognized as special tools.
* Ensure the `terminate` tool is treated as special even when invoked via MCP, e.g. `mcp_server_id_terminate`.
* Align `_should_finish_execution` logic with MCP naming conventions so that calls to MCP `terminate` tools correctly finish the agent execution.


**Influence**

* Without this change, MCP `terminate` tools are not recognized as special, so:
  * `_handle_special_tool` is never invoked for `mcp_{server_id}_terminate`.
  * The agent may continue executing instead of terminating after a tool-initiated stop signal.

* With the new detection logic:
  * MCP `terminate` tools behave consistently with non-MCP `terminate` tools.
  * Tool-initiated termination works reliably in both direct and MCP scenarios, reducing the chance of agents “running on” after a termination request.

**Result**

* `_is_special_tool` now correctly detects:
  * Plain `terminate` (and other special tools) by exact name.
  * MCP-wrapped variants like `mcp_server_id_terminate` by suffix match.
* `_should_finish_execution` now uses a lowercase name and supports both `terminate` and names ending in `_terminate`, aligning with the MCP naming scheme.
* Verified locally that:
  * Calling a non-MCP `terminate` tool still terminates the agent as before.
  * Calling an MCP `terminate` tool (e.g. `mcp_test_terminate`) correctly triggers special-tool handling and finishes execution.