### PR TITLE
bugfix(requirement.txt): resolve the crewai dependency issue with pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ tiktoken~=0.9.0
 
 html2text~=2024.2.26
 gymnasium~=1.1.1
-pillow~=11.1.0
+pillow~=10.4.0
 browsergym~=0.13.3
 uvicorn~=0.34.0
 unidiff~=0.7.5


### PR DESCRIPTION
## Problem
As developer, 
When clone the project and run `uv pip install -r requirements.txt` and got the following issue, 


```bash
❯ uv pip install -r requirements.txt
  × No solution found when resolving dependencies:
  ╰─▶ Because crawl4ai==0.6.3 depends on pillow>=10.4,<11.dev0 and only the following versions of crawl4ai are available:
          crawl4ai<=0.6.3
          crawl4ai>0.7.dev0
      we can conclude that crawl4ai>=0.6.3,<0.7.dev0 depends on pillow>=10.4,<11.dev0.
      And because you require pillow>=11.1.0,<11.2.dev0 and crawl4ai>=0.6.3,<0.7.dev0, we can conclude that your requirements are unsatisfiable.

      hint: `crawl4ai` was requested with a pre-release marker (e.g., crawl4ai>0.6.3,<0.7.dev0), but pre-releases weren't enabled (try: `--prerelease=allow`)
```

The pull request to downgrade the pillow to 10.4.0 to make it work. 