### PR TITLE
fix: downgrade pillow to 10.4.0 to resolve dependency conflict with crawl4ai

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ tiktoken~=0.9.0
 
 html2text~=2024.2.26
 gymnasium~=1.1.1
-pillow~=11.1.0
+pillow~=10.4.0
 browsergym~=0.13.3
 uvicorn~=0.34.0
 unidiff~=0.7.5


### PR DESCRIPTION

**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Fix dependency conflict between `pillow` and `crawl4ai` that prevents package installation
- Downgrade `pillow` from `~=11.1.0` to `~=10.4.0` to ensure compatibility with `crawl4ai==0.6.3`

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

N/A (Minor dependency version fix)

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

This change resolves the installation failure when running `uv pip install -r requirements.txt`. 

**Root cause:** `crawl4ai==0.6.3` requires `pillow>=10.4,<11.dev0` (does not support pillow 11.x), which conflicts with the current `pillow~=11.1.0` requirement.

**Impact:** Users will be able to successfully install all dependencies without conflicts. Pillow 10.4.0 maintains all required functionality while ensuring compatibility with crawl4ai.

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

Before the fix:
```
× No solution found when resolving dependencies:
  ╰─▶ Because crawl4ai==0.6.3 depends on pillow>=10.4,<11.dev0 and only the following
      versions of crawl4ai are available:
          crawl4ai<=0.6.3
          crawl4ai>0.7.dev0
      we can conclude that crawl4ai>=0.6.3,<0.7.dev0 depends on pillow>=10.4,<11.dev0.
      And because you require pillow>=11.1.0,<11.2.dev0 and crawl4ai>=0.6.3,<0.7.dev0, we
      can conclude that your requirements are unsatisfiable.
```

After the fix:
- ✅ `uv pip install -r requirements.txt` completes successfully
- ✅ No dependency conflicts reported

**Other**
<!-- Additional notes about this PR. -->

This is a minimal change that only affects the pillow version specification. No code changes are required, and the downgrade to pillow 10.4.0 does not impact any existing functionality.
