### PR TITLE
add streamable http for mcp server

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -85,6 +85,15 @@ class Manus(ToolCallAgent):
                         logger.info(
                             f"Connected to MCP server {server_id} using command {server_config.command}"
                         )
+                elif server_config.type == "streamableHttp":
+                    if server_config.url:
+                        await self.connect_mcp_server(
+                            server_config.url,
+                            server_id,
+                            use_http_stream=True,
+                            headers=server_config.headers
+                        )
+                        logger.info(f"Connected to streamableHttp server {server_id} at {server_config.url}")
             except Exception as e:
                 logger.error(f"Failed to connect to MCP server {server_id}: {e}")
 
@@ -93,12 +102,19 @@ class Manus(ToolCallAgent):
         server_url: str,
         server_id: str = "",
         use_stdio: bool = False,
+        use_http_stream: bool = False,
         stdio_args: List[str] = None,
+        headers: dict = None,
     ) -> None:
         """Connect to an MCP server and add its tools."""
         if use_stdio:
             await self.mcp_clients.connect_stdio(
                 server_url, stdio_args or [], server_id
+            )
+            self.connected_servers[server_id or server_url] = server_url
+        elif use_http_stream:  # streamable http
+            await self.mcp_clients.connect_streamable_http(
+                server_url=server_url, server_id=server_id, headers=headers
             )
             self.connected_servers[server_id or server_url] = server_url
         else:

--- a/app/config.py
+++ b/app/config.py
@@ -133,6 +133,7 @@ class MCPServerConfig(BaseModel):
     args: List[str] = Field(
         default_factory=list, description="Arguments for stdio command"
     )
+    headers: Dict[str, str] = Field(default_factory=dict, description="HTTP headers")
 
 
 class MCPSettings(BaseModel):
@@ -164,6 +165,7 @@ class MCPSettings(BaseModel):
                         type=server_config["type"],
                         url=server_config.get("url"),
                         command=server_config.get("command"),
+                        headers=server_config.get("headers", {}),
                         args=server_config.get("args", []),
                     )
                 return servers

--- a/config/mcp.example.json
+++ b/config/mcp.example.json
@@ -3,6 +3,13 @@
       "server1": {
         "type": "sse",
         "url": "http://localhost:8000/sse"
+      },
+      "server2": {
+        "type": "streamableHttp",
+        "url": "https://your_streamable_http_mcp_server/mcp",
+        "headers": {
+          "header": "content-type: application/json"
+        }
       }
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ docker~=7.1.0
 pytest~=8.3.5
 pytest-asyncio~=0.25.3
 
-mcp~=1.5.0
+mcp~=1.9.0
 httpx>=0.27.0
 tomli>=2.0.0
 
@@ -36,7 +36,10 @@ boto3~=1.37.18
 
 requests~=2.32.3
 beautifulsoup4~=4.13.3
-crawl4ai~=0.6.3
+crawl4ai>=0.6.3
 
 huggingface-hub~=0.29.2
 setuptools~=75.8.0
+
+structlog
+daytona


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Added support for MCP's streamable HTTP format to enable real-time data streaming via HTTP
- Upgraded MCP package version to ≥1.9.0 (required for streamable HTTP functionality)
- Fixed missing dependencies in requirements.txt that caused application startup failures

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

**Other**
<!-- Additional notes about this PR. -->
