### PR TITLE
fix: update agent count display in PlanningFlow

### DIFF
--- a/app/flow/planning.py
+++ b/app/flow/planning.py
@@ -154,7 +154,7 @@ class PlanningFlow(BaseFlow):
         if len(agents_description) > 1:
             # Add description of agents to select
             system_message_content += (
-                f"\nNow we have {agents_description} agents. "
+                f"\nNow we have {len(agents_description)} agents. "
                 f"The infomation of them are below: {json.dumps(agents_description)}\n"
                 "When creating steps in the planning tool, please specify the agent names using the format '[agent_name]'."
             )


### PR DESCRIPTION
**Features**
- Fixed an issue where the `agents_description` list was passed instead of its length (`len()`) in the system prompt.

**Feature Docs**
- 

**Influence**
- Ensures the prompt displays the correct number of agents instead of dumping the raw list object into the sentence.

**Result**
- The system prompt now correctly displays "Now we have 2 agents..." instead of the entire list string.

**Other**
- 