### PR TITLE
fix(setup): add proper entry point for pipx installation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,3 +8,39 @@ if sys.version_info < (3, 11) or sys.version_info > (3, 13):
             ver=".".join(map(str, sys.version_info))
         )
     )
+
+
+def main():
+    """Entry point for the openmanus CLI."""
+    import asyncio
+    import argparse
+    from app.agent.manus import Manus
+    from app.logger import logger
+
+    async def _main():
+        # Parse command line arguments
+        parser = argparse.ArgumentParser(description="Run Manus agent with a prompt")
+        parser.add_argument(
+            "--prompt", type=str, required=False, help="Input prompt for the agent"
+        )
+        args = parser.parse_args()
+
+        # Create and initialize Manus agent
+        agent = await Manus.create()
+        try:
+            # Use command line prompt if provided, otherwise ask for input
+            prompt = args.prompt if args.prompt else input("Enter your prompt: ")
+            if not prompt.strip():
+                logger.warning("Empty prompt provided.")
+                return
+
+            logger.warning("Processing your request...")
+            await agent.run(prompt)
+            logger.info("Request processing completed.")
+        except KeyboardInterrupt:
+            logger.warning("Operation interrupted.")
+        finally:
+            # Ensure agent resources are cleaned up before exiting
+            await agent.cleanup()
+
+    asyncio.run(_main())

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     python_requires=">=3.12",
     entry_points={
         "console_scripts": [
-            "openmanus=main:main",
+            "openmanus=app:main",
         ],
     },
 )


### PR DESCRIPTION
**Features**

- Fix pipx/mise installation failure by adding proper package-level entry point
- Move CLI entry point from standalone `main.py` to `app:main` 
- Maintain identical functionality and argument parsing

**Feature Docs**

- pipx installation: https://pypa.github.io/pipx/
- setuptools entry_points: https://setuptools.pypa.io/en/latest/userguide/entry_point.html

**Influence**

This change fixes the installation error:

```
error: Failed to install entrypoints for `openmanus`
No executables are provided by package `openmanus`
```

The issue was that `setup.py` referenced `main:main`, but `main.py` sits at the repo 
root (not inside the `app/` package). When pipx installs the package, only the `app/` 
directory is available as an importable package, so the entry point couldn't find `main`.

**Changes**

1. `app/__init__.py`: Added `main()` function that wraps the async CLI logic
2. `setup.py`: Changed entry point from `main:main` to `app:main`

**Testing**

- [ ] pipx install git+https://github.com/ramarivera/OpenManus.git@fix/pipx-entry-point
- [ ] `openmanus --help` works
- [ ] `openmanus --prompt "test"` works

**Related**

- Similar to PR #1 (missing application entry point)

🤖 *This content was generated with AI assistance using Kimi 2.5.*