### PR TITLE
Change daytona_api_key to Optional with default None

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -106,7 +106,7 @@ class SandboxSettings(BaseModel):
 
 
 class DaytonaSettings(BaseModel):
-    daytona_api_key: str
+    daytona_api_key: Optional[str] = Field(None, description="Daytona API key")
     daytona_server_url: Optional[str] = Field(
         "https://app.daytona.io/api", description=""
     )


### PR DESCRIPTION
Change daytona_api_key to Optional with default None to satisfy Pydantic constraints

**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Fixes Pydantic requirement in `config.py` that prevents user from running `python main.py` after initial installation.


**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

**Other**
<!-- Additional notes about this PR. -->
<img width="987" height="439" alt="image" src="https://github.com/user-attachments/assets/5ecea668-a332-48ba-97f4-6d3b68f9001b" />