### PR TITLE
fix: correct typos in prompts and tool descriptions

### DIFF
--- a/app/prompt/visualization.py
+++ b/app/prompt/visualization.py
@@ -1,4 +1,4 @@
-SYSTEM_PROMPT = """You are an AI agent designed to data analysis / visualization task. You have various tools at your disposal that you can call upon to efficiently complete complex requests.
+SYSTEM_PROMPT = """You are an AI agent designed for data analysis / visualization task. You have various tools at your disposal that you can call upon to efficiently complete complex requests.
 # Note:
 1. The workspace directory is: {directory}; Read / write file in workspace
 2. Generate analysis conclusion report in the end"""

--- a/app/tool/chart_visualization/python_execute.py
+++ b/app/tool/chart_visualization/python_execute.py
@@ -22,9 +22,9 @@ class NormalPythonExecute(PythonExecute):
 # Note
 1. The code should generate a comprehensive text-based report containing dataset overview, column details, basic statistics, derived metrics, timeseries comparisons, outliers, and key insights.
 2. Use print() for all outputs so the analysis (including sections like 'Dataset Overview' or 'Preprocessing Results') is clearly visible and save it also
-3. Save any report / processed files / each analysis result in worksapce directory: {directory}
+3. Save any report / processed files / each analysis result in workspace directory: {directory}
 4. Data reports need to be content-rich, including your overall analysis process and corresponding data visualization.
-5. You can invode this tool step-by-step to do data analysis from summary to in-depth with data report saved also""".format(
+5. You can invoke this tool step-by-step to do data analysis from summary to in-depth with data report saved also""".format(
                     directory=config.workspace_root
                 ),
             },


### PR DESCRIPTION
## Summary
Fixed 3 typos in the OpenManus codebase:

1. **app/prompt/visualization.py**
   - `designed to data analysis` → `designed for data analysis`

2. **app/tool/chart_visualization/python_execute.py**
   - `worksapce` → `workspace` (line 25)
   - `invode` → `invoke` (line 27)

## Changes
- 2 files changed
- 3 insertions(+), 3 deletions(-)

## Testing
- Local syntax check passed