### PR TITLE
fix: prevent excessive log file creation on each run

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -1,5 +1,4 @@
 import sys
-from datetime import datetime
 
 from loguru import logger as _logger
 
@@ -14,15 +13,16 @@ def define_log_level(print_level="INFO", logfile_level="DEBUG", name: str = None
     global _print_level
     _print_level = print_level
 
-    current_date = datetime.now()
-    formatted_date = current_date.strftime("%Y%m%d%H%M%S")
-    log_name = (
-        f"{name}_{formatted_date}" if name else formatted_date
-    )  # name a log with prefix name
+    log_name = name or "openmanus"
 
     _logger.remove()
     _logger.add(sys.stderr, level=print_level)
-    _logger.add(PROJECT_ROOT / f"logs/{log_name}.log", level=logfile_level)
+    _logger.add(
+        PROJECT_ROOT / f"logs/{log_name}_{{time:YYYYMMDD}}.log",
+        level=logfile_level,
+        rotation="00:00",
+        retention="7 days",
+    )
     return _logger
 
 


### PR DESCRIPTION
**Features**

- Fix #1008: each program run created a new log file with a second-precision timestamp (e.g. `20250329143025.log`), causing a large number of blank or small log files to accumulate in the `logs/` directory.
- Now uses date-based filenames (e.g. `openmanus_20250329.log`) so all runs on the same day append to the same file.
- Added daily rotation at midnight and 7-day retention via loguru's built-in features.

**Influence**

- Only affects `app/logger.py` — no changes to any other module.
- Existing log imports (`from app.logger import logger`) continue to work without modification.
- The `define_log_level(name=...)` parameter still works: named loggers produce files like `myname_20250329.log`.

**Result**

Before: each run creates a new timestamped log file
```
logs/
  20250329143025.log
  20250329143128.log
  20250329144512.log
  ...
```

After: one log file per day, auto-rotated and cleaned up
```
logs/
  openmanus_20250329.log
  openmanus_20250328.log
```

**Other**

Removed unused `from datetime import datetime` import.