### PR TITLE
fix: correct HTTP header key from 'WebSearch' to 'User-Agent'

### DIFF
--- a/app/tool/web_search.py
+++ b/app/tool/web_search.py
@@ -119,7 +119,7 @@ class WebContentFetcher:
             Extracted text content or None if fetching fails
         """
         headers = {
-            "WebSearch": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
         }
 
         try:


### PR DESCRIPTION
**Features**

- Fix #1334: The headers dict in `web_search.py` line 122 used `"WebSearch"` as the HTTP header key instead of the standard `"User-Agent"`. The User-Agent header was never sent, which could cause requests to be blocked.

**Influence**

- Only affects `app/tool/web_search.py` — one line change.

**Result**

Requests now correctly include the `User-Agent` header.