### PR TITLE
feat: add rotating User-Agent headers & pre-tool-call guardrail authorization layer

### DIFF
--- a/app/tool/__init__.py
+++ b/app/tool/__init__.py
@@ -1,4 +1,11 @@
-from app.tool.base import BaseTool
+from app.tool.base import (
+    AllowlistGuardrail,
+    BaseTool,
+    CLIResult,
+    GuardrailCheckResult,
+    ToolFailure,
+    ToolResult,
+)
 from app.tool.bash import Bash
 from app.tool.browser_use_tool import BrowserUseTool
 from app.tool.crawl4ai import Crawl4aiTool
@@ -11,14 +18,19 @@ from app.tool.web_search import WebSearch
 
 
 __all__ = [
+    "AllowlistGuardrail",
     "BaseTool",
     "Bash",
     "BrowserUseTool",
-    "Terminate",
-    "StrReplaceEditor",
-    "WebSearch",
-    "ToolCollection",
+    "CLIResult",
     "CreateChatCompletion",
-    "PlanningTool",
     "Crawl4aiTool",
+    "GuardrailCheckResult",
+    "PlanningTool",
+    "StrReplaceEditor",
+    "Terminate",
+    "ToolCollection",
+    "ToolFailure",
+    "ToolResult",
+    "WebSearch",
 ]

--- a/app/tool/base.py
+++ b/app/tool/base.py
@@ -7,34 +7,6 @@ from pydantic import BaseModel, Field
 from app.utils.logger import logger
 
 
-# class BaseTool(ABC, BaseModel):
-#     name: str
-#     description: str
-#     parameters: Optional[dict] = None
-
-#     class Config:
-#         arbitrary_types_allowed = True
-
-#     async def __call__(self, **kwargs) -> Any:
-#         """Execute the tool with given parameters."""
-#         return await self.execute(**kwargs)
-
-#     @abstractmethod
-#     async def execute(self, **kwargs) -> Any:
-#         """Execute the tool with given parameters."""
-
-#     def to_param(self) -> Dict:
-#         """Convert tool to function call format."""
-#         return {
-#             "type": "function",
-#             "function": {
-#                 "name": self.name,
-#                 "description": self.description,
-#                 "parameters": self.parameters,
-#             },
-#         }
-
-
 class ToolResult(BaseModel):
     """Represents the result of a tool execution."""
 
@@ -71,8 +43,8 @@ class ToolResult(BaseModel):
 
     def replace(self, **kwargs):
         """Returns a new ToolResult with the given fields replaced."""
-        # return self.copy(update=kwargs)
         return type(self)(**{**self.dict(), **kwargs})
+
 
 class GuardrailCheckResult(BaseModel):
     """Represents the result of a guardrail check before tool execution."""
@@ -171,57 +143,22 @@ class BaseTool(ABC, BaseModel):
         parameters (dict): Tool parameters schema
         guardrail_provider (Optional[GuardrailProvider]): Authorization hook called before execute().
             If None, all calls are allowed by default. Default: None.
-        _schemas (Dict[str, List[ToolSchema]]): Registered method schemas
     """
 
     name: str
     description: str
     parameters: Optional[dict] = None
     guardrail_provider: Optional[GuardrailProvider] = Field(default=None, exclude=True)
-    # _schemas: Dict[str, List[ToolSchema]] = {}
 
     class Config:
         arbitrary_types_allowed = True
         underscore_attrs_are_private = False
 
-    # def __init__(self, **data):
-    #     """Initialize tool with model validation and schema registration."""
-    #     super().__init__(**data)
-    #     logger.debug(f"Initializing tool class: {self.__class__.__name__}")
-    #     self._register_schemas()
-
-    # def _register_schemas(self):
-    #     """Register schemas from all decorated methods."""
-    #     for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
-    #         if hasattr(method, 'tool_schemas'):
-    #             self._schemas[name] = method.tool_schemas
-    #             logger.debug(f"Registered schemas for method '{name}' in {self.__class__.__name__}")
-
     async def __call__(self, **kwargs) -> Any:
-        """Execute the tool with given parameters."""
-        return await self.execute(**kwargs)
+        """Execute the tool with guardrail check, then delegate to execute()."""
+        return await self._run_with_guardrail(**kwargs)
 
-    @abstractmethod
-    async def execute(self, **kwargs) -> Any:
-        """Execute the tool with given parameters.
-
-        Subclasses should override this method with their actual tool logic.
-        The guardrail check (if configured) is called automatically by this base class.
-        """
-
-    async def _execute(self, **kwargs) -> ToolResult:
-        """
-        Internal execution method that runs after guardrail check passes.
-
-        Override this in subclasses instead of `execute()` if you want
-        the guardrail check to be applied automatically.
-        """
-        result = await self.execute(**kwargs)
-        if isinstance(result, ToolResult):
-            return result
-        return self.success_response(result)
-
-    async def _run_with_guardrail(self, **kwargs) -> ToolResult:
+    async def _run_with_guardrail(self, **kwargs) -> Any:
         """Execute with guardrail authorization check.
 
         This method checks the guardrail before executing the tool.
@@ -230,15 +167,21 @@ class BaseTool(ABC, BaseModel):
         if self.guardrail_provider is not None:
             check_result = await self.guardrail_provider.check(self.name, kwargs)
             if not check_result.allowed:
-                from app.utils.logger import logger
-
                 logger.warning(
                     f"Guardrail denied tool '{self.name}': {check_result.reason}"
                 )
                 return ToolResult(
                     error=f"Tool call denied by guardrail: {check_result.reason}"
                 )
-        return await self._execute(**kwargs)
+        return await self.execute(**kwargs)
+
+    @abstractmethod
+    async def execute(self, **kwargs) -> Any:
+        """Execute the tool with given parameters.
+
+        Subclasses must override this method with their actual tool logic.
+        The guardrail check (if configured) is called automatically via __call__.
+        """
 
     def to_param(self) -> Dict:
         """Convert tool to function call format.
@@ -255,14 +198,6 @@ class BaseTool(ABC, BaseModel):
             },
         }
 
-    # def get_schemas(self) -> Dict[str, List[ToolSchema]]:
-    #     """Get all registered tool schemas.
-
-    #     Returns:
-    #         Dict mapping method names to their schema definitions
-    #     """
-    #     return self._schemas
-
     def success_response(self, data: Union[Dict[str, Any], str]) -> ToolResult:
         """Create a successful tool result.
 
@@ -278,15 +213,6 @@ class BaseTool(ABC, BaseModel):
             text = json.dumps(data, indent=2)
         logger.debug(f"Created success response for {self.__class__.__name__}")
         return ToolResult(output=text)
-
-    async def execute(self, **kwargs) -> ToolResult:
-        """Execute the tool with guardrail check.
-
-        This base implementation applies the guardrail check and then
-        delegates to the subclass's actual execution logic.
-        Subclasses should override `_execute()` for their logic.
-        """
-        return await self._run_with_guardrail(**kwargs)
 
     def fail_response(self, msg: str) -> ToolResult:
         """Create a failed tool result.

--- a/app/tool/base.py
+++ b/app/tool/base.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Protocol, Union
 
 from pydantic import BaseModel, Field
 
@@ -74,6 +74,86 @@ class ToolResult(BaseModel):
         # return self.copy(update=kwargs)
         return type(self)(**{**self.dict(), **kwargs})
 
+class GuardrailCheckResult(BaseModel):
+    """Represents the result of a guardrail check before tool execution."""
+
+    allowed: bool = Field(description="Whether the tool call is allowed")
+    reason: Optional[str] = Field(
+        default=None,
+        description="Reason for denial (if not allowed) or informational message (if allowed)",
+    )
+
+    def __bool__(self):
+        return self.allowed
+
+
+class GuardrailProvider(Protocol):
+    """
+    Protocol for pluggable guardrail providers.
+
+    Implement this protocol to add custom authorization logic
+    before a tool is executed. For example:
+    - Allowlist/blocklist-based filtering
+    - Rate limiting
+    - Cost estimation
+    - Audit logging
+
+    Example:
+        class AllowlistGuardrail:
+            async def check(self, tool_name: str, args: dict) -> GuardrailCheckResult:
+                if tool_name in self.allowed_tools:
+                    return GuardrailCheckResult(allowed=True, reason="Tool is allowed")
+                return GuardrailCheckResult(allowed=False, reason=f"Tool '{tool_name}' is not allowed")
+    """
+
+    async def check(self, tool_name: str, args: dict) -> GuardrailCheckResult:
+        """Check if the tool call is authorized.
+
+        Args:
+            tool_name: Name of the tool being called
+            args: Arguments passed to the tool
+
+        Returns:
+            GuardrailCheckResult indicating whether the call should proceed
+        """
+        ...
+
+
+class AllowlistGuardrail:
+    """
+    Built-in allowlist-based guardrail provider.
+
+    Simple implementation that maintains a list of allowed tool names.
+    All other tools are denied by default.
+    """
+
+    def __init__(self, allowed_tools: Optional[List[str]] = None):
+        """
+        Initialize the allowlist guardrail.
+
+        Args:
+            allowed_tools: List of tool names that are allowed to execute.
+                          If None, all tools are allowed.
+        """
+        self.allowed_tools: Optional[List[str]] = allowed_tools
+
+    async def check(self, tool_name: str, args: dict) -> GuardrailCheckResult:
+        """Check if the tool is in the allowlist."""
+        if self.allowed_tools is None:
+            return GuardrailCheckResult(
+                allowed=True,
+                reason="AllowlistGuardrail: no restriction (allowed_tools is None)",
+            )
+        if tool_name in self.allowed_tools:
+            return GuardrailCheckResult(
+                allowed=True,
+                reason=f"Tool '{tool_name}' is in the allowlist",
+            )
+        return GuardrailCheckResult(
+            allowed=False,
+            reason=f"Tool '{tool_name}' is not in the allowlist. Allowed tools: {self.allowed_tools}",
+        )
+
 
 class BaseTool(ABC, BaseModel):
     """Consolidated base class for all tools combining BaseModel and Tool functionality.
@@ -83,17 +163,21 @@ class BaseTool(ABC, BaseModel):
     - Schema registration
     - Standardized result handling
     - Abstract execution interface
+    - Pre-execution guardrail authorization (optional)
 
     Attributes:
         name (str): Tool name
         description (str): Tool description
         parameters (dict): Tool parameters schema
+        guardrail_provider (Optional[GuardrailProvider]): Authorization hook called before execute().
+            If None, all calls are allowed by default. Default: None.
         _schemas (Dict[str, List[ToolSchema]]): Registered method schemas
     """
 
     name: str
     description: str
     parameters: Optional[dict] = None
+    guardrail_provider: Optional[GuardrailProvider] = Field(default=None, exclude=True)
     # _schemas: Dict[str, List[ToolSchema]] = {}
 
     class Config:
@@ -119,7 +203,42 @@ class BaseTool(ABC, BaseModel):
 
     @abstractmethod
     async def execute(self, **kwargs) -> Any:
-        """Execute the tool with given parameters."""
+        """Execute the tool with given parameters.
+
+        Subclasses should override this method with their actual tool logic.
+        The guardrail check (if configured) is called automatically by this base class.
+        """
+
+    async def _execute(self, **kwargs) -> ToolResult:
+        """
+        Internal execution method that runs after guardrail check passes.
+
+        Override this in subclasses instead of `execute()` if you want
+        the guardrail check to be applied automatically.
+        """
+        result = await self.execute(**kwargs)
+        if isinstance(result, ToolResult):
+            return result
+        return self.success_response(result)
+
+    async def _run_with_guardrail(self, **kwargs) -> ToolResult:
+        """Execute with guardrail authorization check.
+
+        This method checks the guardrail before executing the tool.
+        Returns a denied ToolResult if the guardrail rejects the call.
+        """
+        if self.guardrail_provider is not None:
+            check_result = await self.guardrail_provider.check(self.name, kwargs)
+            if not check_result.allowed:
+                from app.utils.logger import logger
+
+                logger.warning(
+                    f"Guardrail denied tool '{self.name}': {check_result.reason}"
+                )
+                return ToolResult(
+                    error=f"Tool call denied by guardrail: {check_result.reason}"
+                )
+        return await self._execute(**kwargs)
 
     def to_param(self) -> Dict:
         """Convert tool to function call format.
@@ -159,6 +278,15 @@ class BaseTool(ABC, BaseModel):
             text = json.dumps(data, indent=2)
         logger.debug(f"Created success response for {self.__class__.__name__}")
         return ToolResult(output=text)
+
+    async def execute(self, **kwargs) -> ToolResult:
+        """Execute the tool with guardrail check.
+
+        This base implementation applies the guardrail check and then
+        delegates to the subclass's actual execution logic.
+        Subclasses should override `_execute()` for their logic.
+        """
+        return await self._run_with_guardrail(**kwargs)
 
     def fail_response(self, msg: str) -> ToolResult:
         """Create a failed tool result.

--- a/app/tool/web_search.py
+++ b/app/tool/web_search.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Any, Dict, List, Optional
 
+import random
 import requests
 from bs4 import BeautifulSoup
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -103,6 +104,16 @@ class SearchResponse(ToolResult):
         return self
 
 
+# Realistic User-Agent pool for web scraping
+_USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15",
+]
+
+
 class WebContentFetcher:
     """Utility class for fetching web content."""
 
@@ -119,7 +130,7 @@ class WebContentFetcher:
             Extracted text content or None if fetching fails
         """
         headers = {
-            "WebSearch": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            "User-Agent": random.choice(_USER_AGENTS)
         }
 
         try:


### PR DESCRIPTION
## Summary

This PR combines two improvements to OpenManus's tool infrastructure:

1. **Rotating User-Agent for WebSearch** — `WebContentFetcher` now randomly selects from a pool of 5 realistic User-Agent strings (Chrome/Firefox/Safari across Windows/macOS/Linux) on each request, preventing web servers from detecting and blocking automated scraping based on a fixed header.

2. **Pre-tool-call Guardrail Authorization** — Adds a pluggable authorization layer to `BaseTool`, implementing the OAP `before_tool_call` pattern. A `GuardrailProvider` protocol is evaluated in `BaseTool.__call__()` before `execute()`, returning allow/deny with reasons. Denied calls return a `ToolResult(error=...)` without executing the underlying tool logic. Fully backward compatible — if no guardrail provider is set, all calls are allowed by default.

## Changes

- `app/tool/web_search.py`: Added `random` import and `_USER_AGENTS` pool; `WebContentFetcher` now rotates User-Agent per request
- `app/tool/base.py`: Added `GuardrailCheckResult` model, `GuardrailProvider` Protocol, `AllowlistGuardrail` built-in implementation, and `_run_with_guardrail()` hook in `BaseTool`
- `app/tool/__init__.py`: Updated exports to include `GuardrailCheckResult`, `AllowlistGuardrail`, `CLIResult`, `ToolFailure`, `ToolResult`

## Why this matters

- **User-Agent rotation** avoids request blocking on content-heavy web search tasks
- **Guardrail layer** enables blocking dangerous operations, rate-limiting expensive calls, audit logging, and enterprise compliance — without modifying any existing tool subclass

## Backward compatibility

- No changes required to any `BaseTool` subclass
- Existing tools without `guardrail_provider` continue to work as before
- `WebContentFetcher` API unchanged, only internal header selection logic updated
