### PR TITLE
fix: wrap PythonExecute's blocking multiprocessing in run_in_executor to unblock event loop

### DIFF
--- a/app/tool/python_execute.py
+++ b/app/tool/python_execute.py
@@ -1,3 +1,4 @@
+import asyncio
 import multiprocessing
 import sys
 from io import StringIO
@@ -36,6 +37,30 @@ class PythonExecute(BaseTool):
         finally:
             sys.stdout = original_stdout
 
+    def _run_in_process(self, code: str, timeout: int) -> Dict:
+        """Run code in a subprocess. This method is blocking and should be
+        called via run_in_executor to avoid blocking the event loop."""
+        with multiprocessing.Manager() as manager:
+            result = manager.dict({"observation": "", "success": False})
+            if isinstance(__builtins__, dict):
+                safe_globals = {"__builtins__": __builtins__}
+            else:
+                safe_globals = {"__builtins__": __builtins__.__dict__.copy()}
+            proc = multiprocessing.Process(
+                target=self._run_code, args=(code, result, safe_globals)
+            )
+            proc.start()
+            proc.join(timeout)
+
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(1)
+                return {
+                    "observation": f"Execution timeout after {timeout} seconds",
+                    "success": False,
+                }
+            return dict(result)
+
     async def execute(
         self,
         code: str,
@@ -49,27 +74,7 @@ class PythonExecute(BaseTool):
             timeout (int): Execution timeout in seconds.
 
         Returns:
-            Dict: Contains 'output' with execution output or error message and 'success' status.
+            Dict: Contains 'observation' with execution output or error message and 'success' status.
         """
-
-        with multiprocessing.Manager() as manager:
-            result = manager.dict({"observation": "", "success": False})
-            if isinstance(__builtins__, dict):
-                safe_globals = {"__builtins__": __builtins__}
-            else:
-                safe_globals = {"__builtins__": __builtins__.__dict__.copy()}
-            proc = multiprocessing.Process(
-                target=self._run_code, args=(code, result, safe_globals)
-            )
-            proc.start()
-            proc.join(timeout)
-
-            # timeout process
-            if proc.is_alive():
-                proc.terminate()
-                proc.join(1)
-                return {
-                    "observation": f"Execution timeout after {timeout} seconds",
-                    "success": False,
-                }
-            return dict(result)
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, self._run_in_process, code, timeout)


### PR DESCRIPTION

**## Summary**

`PythonExecute.execute()` is an `async` method but internally calls `multiprocessing.Process.start()` + `proc.join(timeout)` synchronously. `proc.join()` is a blocking call that halts the entire asyncio event loop for up to `timeout` seconds (default 5s), preventing all other concurrent coroutines (LLM calls, web fetches, other tool executions) from making progress.

This PR wraps the blocking multiprocessing work in `asyncio.get_event_loop().run_in_executor()` so it runs in a thread pool, keeping the event loop free.

**## Changes**

- `app/tool/python_execute.py`: Extracted the synchronous `multiprocessing.Manager` + `Process.join` block into a private `_run_in_process()` method, and called it via `run_in_executor(None, ...)` from the async `execute()` method

**## Why this matters**

In a typical OpenManus session, multiple tools may be active concurrently — the LLM is streaming, web searches are in flight, browser actions are pending. When `PythonExecute` blocks the event loop for 5 seconds (or longer with a custom timeout), all of these stall completely. This is especially painful when chained with other async tools in a planning flow.

**## Test plan**

- [ ] `python -m py_compile app/tool/python_execute.py` passes
- [ ] `await PythonExecute().execute(code="print('hello')")` returns `{"observation": "hello\n", "success": True}`
- [ ] `await PythonExecute().execute(code="import time; time.sleep(10)", timeout=2)` returns timeout error without blocking the event loop for 10s
- [ ] Other async tasks continue to run while `PythonExecute` is waiting for its subprocess