### PR TITLE
security: sanitize user inputs in SandboxShellTool to prevent shell command injection

### DIFF
--- a/app/tool/sandbox/sb_shell_tool.py
+++ b/app/tool/sandbox/sb_shell_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import shlex
 import time
 from typing import Any, Dict, Optional, TypeVar
 from uuid import uuid4
@@ -157,25 +158,29 @@ class SandboxShellTool(SandboxToolsBase):
             if not session_name:
                 session_name = f"session_{str(uuid4())[:8]}"
 
+            # Quote session_name and cwd to prevent shell injection
+            quoted_session = shlex.quote(session_name)
+            quoted_cwd = shlex.quote(cwd)
+
             # Check if tmux session already exists
             check_session = await self._execute_raw_command(
-                f"tmux has-session -t {session_name} 2>/dev/null || echo 'not_exists'"
+                f"tmux has-session -t {quoted_session} 2>/dev/null || echo 'not_exists'"
             )
             session_exists = "not_exists" not in check_session.get("output", "")
 
             if not session_exists:
                 # Create a new tmux session
                 await self._execute_raw_command(
-                    f"tmux new-session -d -s {session_name}"
+                    f"tmux new-session -d -s {quoted_session}"
                 )
 
             # Ensure we're in the correct directory and send command to tmux
-            full_command = f"cd {cwd} && {command}"
+            full_command = f"cd {quoted_cwd} && {command}"
             wrapped_command = full_command.replace('"', '\\"')  # Escape double quotes
 
             # Send command to tmux session
             await self._execute_raw_command(
-                f'tmux send-keys -t {session_name} "{wrapped_command}" Enter'
+                f'tmux send-keys -t {quoted_session} "{wrapped_command}" Enter'
             )
 
             if blocking:
@@ -187,14 +192,14 @@ class SandboxShellTool(SandboxToolsBase):
 
                     # Check if session still exists (command might have exited)
                     check_result = await self._execute_raw_command(
-                        f"tmux has-session -t {session_name} 2>/dev/null || echo 'ended'"
+                        f"tmux has-session -t {quoted_session} 2>/dev/null || echo 'ended'"
                     )
                     if "ended" in check_result.get("output", ""):
                         break
 
                     # Get current output and check for common completion indicators
                     output_result = await self._execute_raw_command(
-                        f"tmux capture-pane -t {session_name} -p -S - -E -"
+                        f"tmux capture-pane -t {quoted_session} -p -S - -E -"
                     )
                     current_output = output_result.get("output", "")
 
@@ -218,12 +223,12 @@ class SandboxShellTool(SandboxToolsBase):
 
                 # Capture final output
                 output_result = await self._execute_raw_command(
-                    f"tmux capture-pane -t {session_name} -p -S - -E -"
+                    f"tmux capture-pane -t {quoted_session} -p -S - -E -"
                 )
                 final_output = output_result.get("output", "")
 
                 # Kill the session after capture
-                await self._execute_raw_command(f"tmux kill-session -t {session_name}")
+                await self._execute_raw_command(f"tmux kill-session -t {quoted_session}")
 
                 return self.success_response(
                     {
@@ -249,9 +254,9 @@ class SandboxShellTool(SandboxToolsBase):
             if session_name:
                 try:
                     await self._execute_raw_command(
-                        f"tmux kill-session -t {session_name}"
+                        f"tmux kill-session -t {shlex.quote(session_name)}"
                     )
-                except:
+                except Exception:
                     pass
             return self.fail_response(f"Error executing command: {str(e)}")
 
@@ -262,9 +267,11 @@ class SandboxShellTool(SandboxToolsBase):
             # Ensure sandbox is initialized
             await self._ensure_sandbox()
 
+            quoted_session = shlex.quote(session_name)
+
             # Check if session exists
             check_result = await self._execute_raw_command(
-                f"tmux has-session -t {session_name} 2>/dev/null || echo 'not_exists'"
+                f"tmux has-session -t {quoted_session} 2>/dev/null || echo 'not_exists'"
             )
             if "not_exists" in check_result.get("output", ""):
                 return self.fail_response(
@@ -273,13 +280,13 @@ class SandboxShellTool(SandboxToolsBase):
 
             # Get output from tmux pane
             output_result = await self._execute_raw_command(
-                f"tmux capture-pane -t {session_name} -p -S - -E -"
+                f"tmux capture-pane -t {quoted_session} -p -S - -E -"
             )
             output = output_result.get("output", "")
 
             # Kill session if requested
             if kill_session:
-                await self._execute_raw_command(f"tmux kill-session -t {session_name}")
+                await self._execute_raw_command(f"tmux kill-session -t {quoted_session}")
                 termination_status = "Session terminated."
             else:
                 termination_status = "Session still running."
@@ -300,9 +307,11 @@ class SandboxShellTool(SandboxToolsBase):
             # Ensure sandbox is initialized
             await self._ensure_sandbox()
 
+            quoted_session = shlex.quote(session_name)
+
             # Check if session exists
             check_result = await self._execute_raw_command(
-                f"tmux has-session -t {session_name} 2>/dev/null || echo 'not_exists'"
+                f"tmux has-session -t {quoted_session} 2>/dev/null || echo 'not_exists'"
             )
             if "not_exists" in check_result.get("output", ""):
                 return self.fail_response(
@@ -310,7 +319,7 @@ class SandboxShellTool(SandboxToolsBase):
                 )
 
             # Kill the session
-            await self._execute_raw_command(f"tmux kill-session -t {session_name}")
+            await self._execute_raw_command(f"tmux kill-session -t {quoted_session}")
 
             return self.success_response(
                 {"message": f"Tmux session '{session_name}' terminated successfully."}


### PR DESCRIPTION

**## Summary**

`SandboxShellTool._execute_command()` constructs shell commands by directly interpolating user-controlled inputs (`session_name`, `folder`, `command`) into f-strings passed to `tmux` and `cd`. A malicious or malformed input like `session_name="foo; rm -rf /"` would be executed verbatim by the shell.

This PR adds `shlex.quote()` sanitization to all user-controlled values before they are interpolated into shell command strings, preventing injection attacks.

**## Changes**

- `app/tool/sandbox/sb_shell_tool.py`:
  - Added `import shlex` at file top
  - Sanitized `session_name` with `shlex.quote()` in all `tmux` commands within `_execute_command()`
  - Sanitized `folder` / `cwd` with `shlex.quote()` in `cd` command construction
  - Sanitized `command` with `shlex.quote()` is NOT applied to the user command itself (it's intentionally a shell command), but the `cwd` and `session_name` wrapping it are protected
  - Applied same sanitization to `_check_command_output()` and `_terminate_command()`

**## Attack vector example**

```python
# Before this fix, this would execute "rm -rf /" on the host:
await tool.execute(
    action="execute_command",
    command="echo hello",
    session_name='foo"; rm -rf / #',
)
# Resulting shell command:
#   tmux has-session -t foo"; rm -rf / # 2>/dev/null || echo 'not_exists'
```

After this fix, `shlex.quote()` wraps the session name so it becomes a safe literal string.

**## Why this matters**

- `SandboxShellTool` is designed to run in sandbox environments, but the tmux management commands run on the host process
- Any LLM-generated or user-provided `session_name` or `folder` could contain shell metacharacters
- This is a defense-in-depth measure — even if the sandbox isolates execution, the tmux orchestration layer should not be injectable

**## Test plan**

- [ ] `python -m py_compile app/tool/sandbox/sb_shell_tool.py` passes
- [ ] Normal usage: `execute(action="execute_command", command="ls", session_name="my_session")` works as before
- [ ] Injection attempt: `session_name='foo"; echo pwned #'` does NOT execute `echo pwned`
- [ ] Folder with spaces: `folder="my folder/sub dir"` works correctly
- [ ] Backward compatible: all existing callers unaffected (quoting is transparent for clean inputs)