### PR TITLE
fix: correct content preview truncation in crawl4ai and minor fixes

### DIFF
--- a/app/prompt/browser.py
+++ b/app/prompt/browser.py
@@ -50,7 +50,7 @@ Common action sequences:
 5. TASK COMPLETION:
 - Use the done action as the last action as soon as the ultimate task is complete
 - Dont use "done" before you are done with everything the user asked you, except you reach the last step of max_steps.
-- If you reach your last step, use the done action even if the task is not fully finished. Provide all the information you have gathered so far. If the ultimate task is completly finished set success to true. If not everything the user asked for is completed set success in done to false!
+- If you reach your last step, use the done action even if the task is not fully finished. Provide all the information you have gathered so far. If the ultimate task is completely finished set success to true. If not everything the user asked for is completed set success in done to false!
 - If you have to do something repeatedly for example the task says for "each", or "for all", or "x times", count always inside "memory" how many times you have done it and how many remain. Don't stop until you have completed like the task asked you. Only call done after the last step.
 - Don't hallucinate actions
 - Make sure you include everything you found out for the ultimate task in the done text parameter. Do not just say you are done, but include the requested information of the task.

--- a/app/tool/crawl4ai.py
+++ b/app/tool/crawl4ai.py
@@ -226,7 +226,7 @@ class Crawl4aiTool(BaseTool):
 
                     if result.get("markdown"):
                         # Show first 300 characters of markdown content
-                        content_preview = result["markdown"]
+                        content_preview = result["markdown"][:300]
                         if len(result["markdown"]) > 300:
                             content_preview += "..."
                         output_lines.append(f"   📝 Content: {content_preview}")

--- a/app/tool/web_search.py
+++ b/app/tool/web_search.py
@@ -144,7 +144,7 @@ class WebContentFetcher:
             # Get text content
             text = soup.get_text(separator="\n", strip=True)
 
-            # Clean up whitespace and limit size (100KB max)
+            # Clean up whitespace and limit size (~10K chars)
             text = " ".join(text.split())
             return text[:10000] if text else None
 


### PR DESCRIPTION
## Summary
- Fix content preview not being truncated to 300 chars in crawl4ai — previously appended `...` to full content instead of slicing first
- Fix typo `completly` → `completely` in browser prompt
- Fix misleading comment claiming 100KB limit when actual limit is ~10K chars

## Test plan
- [ ] Verify crawl4ai content preview is properly truncated for long content

🤖 Generated with [Claude Code](https://claude.com/claude-code)