### PR TITLE
fix: correct typos and grammar in prompts and config

### DIFF
--- a/app/prompt/browser.py
+++ b/app/prompt/browser.py
@@ -49,7 +49,7 @@ Common action sequences:
 
 5. TASK COMPLETION:
 - Use the done action as the last action as soon as the ultimate task is complete
-- Dont use "done" before you are done with everything the user asked you, except you reach the last step of max_steps.
+- Don't use "done" before you are done with everything the user asked you, except you reach the last step of max_steps.
 - If you reach your last step, use the done action even if the task is not fully finished. Provide all the information you have gathered so far. If the ultimate task is completly finished set success to true. If not everything the user asked for is completed set success in done to false!
 - If you have to do something repeatedly for example the task says for "each", or "for all", or "x times", count always inside "memory" how many times you have done it and how many remain. Don't stop until you have completed like the task asked you. Only call done after the last step.
 - Don't hallucinate actions

--- a/app/prompt/visualization.py
+++ b/app/prompt/visualization.py
@@ -1,4 +1,4 @@
-SYSTEM_PROMPT = """You are an AI agent designed to data analysis / visualization task. You have various tools at your disposal that you can call upon to efficiently complete complex requests.
+SYSTEM_PROMPT = """You are an AI agent designed for data analysis / visualization tasks. You have various tools at your disposal that you can call upon to efficiently complete complex requests.
 # Note:
 1. The workspace directory is: {directory}; Read / write file in workspace
 2. Generate analysis conclusion report in the end"""

--- a/config/config.example-daytona.toml
+++ b/config/config.example-daytona.toml
@@ -111,4 +111,4 @@ server_reference = "app.mcp.server" # default server module reference
 # Optional Runflow configuration
 # Your can add additional agents into run-flow workflow to solve different-type tasks.
 [runflow]
-use_data_analysis_agent = false     # The Data Analysi Agent to solve various data analysis tasks
+use_data_analysis_agent = false     # The Data Analysis Agent to solve various data analysis tasks

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -110,4 +110,4 @@ server_reference = "app.mcp.server" # default server module reference
 # Optional Runflow configuration
 # Your can add additional agents into run-flow workflow to solve different-type tasks.
 [runflow]
-use_data_analysis_agent = false     # The Data Analysi Agent to solve various data analysis tasks
+use_data_analysis_agent = false     # The Data Analysis Agent to solve various data analysis tasks


### PR DESCRIPTION
## Summary
- Fix `Dont` → `Don't` in browser prompt
- Fix `Data Analysi` → `Data Analysis` in config examples (2 files)
- Fix grammar in visualization prompt: `designed to data analysis / visualization task` → `designed for data analysis / visualization tasks`

## Test plan
- [ ] Config and prompt text changes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)