### PR TITLE
fix: fix multiple bugs in web search, prompts, and tool definitions

### DIFF
--- a/app/prompt/manus.py
+++ b/app/prompt/manus.py
@@ -1,5 +1,5 @@
 SYSTEM_PROMPT = (
-    "You are OpenManus, an all-capable AI assistant, aimed at solving any task presented by the user. You have various tools at your disposal that you can call upon to efficiently complete complex requests. Whether it's programming, information retrieval, file processing, web browsing, or human interaction (only for extreme cases), you can handle it all."
+    "You are OpenManus, an all-capable AI assistant, aimed at solving any task presented by the user. You have various tools at your disposal that you can call upon to efficiently complete complex requests. Whether it's programming, information retrieval, file processing, web browsing, or human interaction (only for extreme cases), you can handle it all. "
     "The initial directory is: {directory}"
 )
 

--- a/app/tool/ask_human.py
+++ b/app/tool/ask_human.py
@@ -6,7 +6,7 @@ class AskHuman(BaseTool):
 
     name: str = "ask_human"
     description: str = "Use this tool to ask human for help."
-    parameters: str = {
+    parameters: dict = {
         "type": "object",
         "properties": {
             "inquire": {

--- a/app/tool/search/google_search.py
+++ b/app/tool/search/google_search.py
@@ -21,7 +21,7 @@ class GoogleSearchEngine(WebSearchEngine):
             if isinstance(item, str):
                 # If it's just a URL
                 results.append(
-                    {"title": f"Google Result {i+1}", "url": item, "description": ""}
+                    SearchItem(title=f"Google Result {i+1}", url=item, description="")
                 )
             else:
                 results.append(

--- a/app/tool/web_search.py
+++ b/app/tool/web_search.py
@@ -302,6 +302,7 @@ class WebSearch(BaseTool):
             )
 
             if not search_items:
+                failed_engines.append(engine_name)
                 continue
 
             if failed_engines:

--- a/protocol/a2a/app/agent_executor.py
+++ b/protocol/a2a/app/agent_executor.py
@@ -41,7 +41,7 @@ class ManusExecutor(AgentExecutor):
             result = await self.agent.invoke(query, context.context_id)
             print(f"Final Result ===> {result}")
         except Exception as e:
-            print("Error invoking agent: %s", e)
+            print(f"Error invoking agent: {e}")
             raise ServerError(error=ValueError(f"Error invoking agent: {e}")) from e
         parts = [
             Part(


### PR DESCRIPTION
## Summary
- Fix `failed_engines` list never being populated in web_search.py — logging about failed/retried engines was dead code
- Fix missing space in SYSTEM_PROMPT string concatenation in manus.py
- Fix `print` with `%s` format string in agent_executor.py (should use f-string)
- Fix `GoogleSearchEngine` returning raw dict instead of `SearchItem` object
- Fix wrong type annotation `str` → `dict` in ask_human.py parameters

## Test plan
- [ ] Verify web search correctly logs failed engines
- [ ] Verify SYSTEM_PROMPT renders with proper spacing
- [ ] Verify Google search returns proper SearchItem objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)