### PR TITLE
fix: prevent needless retry of TokenLimitExceeded and fix search engine fallback

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -355,7 +355,7 @@ class LLM:
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_exception_type(
-            (OpenAIError, Exception, ValueError)
+            (OpenAIError, ValueError)
         ),  # Don't retry TokenLimitExceeded
     )
     async def ask(
@@ -482,7 +482,7 @@ class LLM:
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_exception_type(
-            (OpenAIError, Exception, ValueError)
+            (OpenAIError, ValueError)
         ),  # Don't retry TokenLimitExceeded
     )
     async def ask_with_images(
@@ -638,7 +638,7 @@ class LLM:
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_exception_type(
-            (OpenAIError, Exception, ValueError)
+            (OpenAIError, ValueError)
         ),  # Don't retry TokenLimitExceeded
     )
     async def ask_tool(

--- a/app/tool/web_search.py
+++ b/app/tool/web_search.py
@@ -297,11 +297,19 @@ class WebSearch(BaseTool):
         for engine_name in engine_order:
             engine = self._search_engine[engine_name]
             logger.info(f"🔎 Attempting search with {engine_name.capitalize()}...")
-            search_items = await self._perform_search_with_engine(
-                engine, query, num_results, search_params
-            )
+            try:
+                search_items = await self._perform_search_with_engine(
+                    engine, query, num_results, search_params
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Search engine {engine_name.capitalize()} raised an exception: {e}"
+                )
+                failed_engines.append(engine_name)
+                continue
 
             if not search_items:
+                failed_engines.append(engine_name)
                 continue
 
             if failed_engines:


### PR DESCRIPTION
## Summary

This PR fixes two bugs:

### Bug 1: `TokenLimitExceeded` retried 6 times despite intent not to retry it

**File:** `app/llm.py` (3 locations: `ask`, `ask_with_images`, `ask_tool`)

The `@retry` decorator uses `retry_if_exception_type((OpenAIError, Exception, ValueError))`. The comment says "Don't retry TokenLimitExceeded", but since `TokenLimitExceeded` inherits from `Exception`, tenacity matches it and retries 6 times — wasting tokens and time on a condition that cannot succeed on retry.

**Fix:** Remove `Exception` from the tuple. `OpenAIError` and `ValueError` already cover all intended retry cases. `TokenLimitExceeded` (which does **not** inherit from either) will now propagate immediately as intended.

### Bug 2: Search engine fallback broken when an engine raises an exception

**File:** `app/tool/web_search.py`, method `_try_all_engines`

The call to `_perform_search_with_engine()` is not wrapped in `try/except`. If an engine raises an exception (e.g., network error, API key issue), the exception propagates up and the remaining fallback engines are never tried — defeating the purpose of the fallback mechanism.

**Fix:** Wrap the call in `try/except Exception`, log a warning with the engine name and error, append to `failed_engines`, and `continue` to the next engine. Also added `failed_engines.append(engine_name)` when `search_items` is empty so the final log message accurately reports all engines that were attempted.

## Test plan

- [ ] Verify `TokenLimitExceeded` is raised immediately without retries when the token limit is exceeded
- [ ] Verify `OpenAIError` and `ValueError` are still retried up to 6 times
- [ ] Verify that if the first search engine raises an exception, the next engine in the fallback order is tried
- [ ] Verify that if all engines raise exceptions, the error is logged and an empty list is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)