### PR TITLE
fix: resolve dependency conflict between crawl4ai and pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ tiktoken~=0.9.0
 
 html2text~=2024.2.26
 gymnasium~=1.1.1
-pillow~=11.1.0
+pillow>=10.4,<12
 browsergym~=0.13.3
 uvicorn~=0.34.0
 unidiff~=0.7.5
@@ -36,7 +36,7 @@ boto3~=1.37.18
 
 requests~=2.32.3
 beautifulsoup4~=4.13.3
-crawl4ai~=0.6.3
+crawl4ai>=0.6.3
 
 huggingface-hub~=0.29.2
 setuptools~=75.8.0


### PR DESCRIPTION
## Problem

Fixes #1360

Installing via `uv pip install -r requirements.txt` fails with a dependency resolution error:

```
No solution found when resolving dependencies:
Because crawl4ai==0.6.3 depends on pillow>=10.4,<11.dev0
And you require pillow>=11.1.0,<11.2.dev0
```

## Root Cause

- `crawl4ai~=0.6.3` requires `pillow>=10.4,<11.dev0`
- `pillow~=11.1.0` pins `pillow>=11.1.0,<11.2.dev0`

These constraints are mutually exclusive - no version of pillow satisfies both.

## Solution

Relaxed version constraints to allow compatible resolution:

| Package | Before | After |
|---------|--------|-------|
| `pillow` | `~=11.1.0` | `>=10.4,<12` |
| `crawl4ai` | `~=0.6.3` | `>=0.6.3` |

This allows pip/uv to resolve a compatible pillow version (10.4.x through 11.x) that satisfies both crawl4ai and other dependencies.

## Testing

- Verified `uv pip install -r requirements.txt` resolves successfully on macOS and Linux
- No breaking changes to functionality
