### PR TITLE
fix: prevent needless retry of TokenLimitExceeded and fix search engine fallback

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -355,7 +355,7 @@ class LLM:
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_exception_type(
-            (OpenAIError, Exception, ValueError)
+            (OpenAIError, ValueError)
         ),  # Don't retry TokenLimitExceeded
     )
     async def ask(
@@ -482,7 +482,7 @@ class LLM:
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_exception_type(
-            (OpenAIError, Exception, ValueError)
+            (OpenAIError, ValueError)
         ),  # Don't retry TokenLimitExceeded
     )
     async def ask_with_images(
@@ -638,7 +638,7 @@ class LLM:
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
         retry=retry_if_exception_type(
-            (OpenAIError, Exception, ValueError)
+            (OpenAIError, ValueError)
         ),  # Don't retry TokenLimitExceeded
     )
     async def ask_tool(

--- a/app/tool/web_search.py
+++ b/app/tool/web_search.py
@@ -297,11 +297,19 @@ class WebSearch(BaseTool):
         for engine_name in engine_order:
             engine = self._search_engine[engine_name]
             logger.info(f"🔎 Attempting search with {engine_name.capitalize()}...")
-            search_items = await self._perform_search_with_engine(
-                engine, query, num_results, search_params
-            )
+            try:
+                search_items = await self._perform_search_with_engine(
+                    engine, query, num_results, search_params
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Search engine {engine_name.capitalize()} raised an exception: {e}"
+                )
+                failed_engines.append(engine_name)
+                continue
 
             if not search_items:
+                failed_engines.append(engine_name)
                 continue
 
             if failed_engines:


### PR DESCRIPTION
This PR addresses: prevent needless retry of TokenLimitExceeded and fix search engine fallback